### PR TITLE
fix: Normalise commit types when matching to commit logs

### DIFF
--- a/changelog_gen/config.py
+++ b/changelog_gen/config.py
@@ -118,10 +118,12 @@ class Config:
         """Process parser and validate if strict check enabled."""
         self.parser = re.compile(self.parser)
         if self.commit_types != SUPPORTED_TYPES:
+            commit_types = {}
             for k, v in self.commit_types.items():
                 value = json.loads(v) if isinstance(v, str) else v
                 ct = CommitType(**value) if isinstance(value, dict) else value
-                self.commit_types[k] = ct
+                commit_types[k.lower()] = ct
+            self.commit_types = commit_types
 
         if self.strict:
             parts = {component: self.parts.get(component, [0])[0] for component in self.parser.groupindex}

--- a/changelog_gen/extractor.py
+++ b/changelog_gen/extractor.py
@@ -66,14 +66,14 @@ class ChangeExtractor:
         # Build a conventional commit regex based on configured sections
         #   ^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)
         types = "|".join(self.type_headers.keys())
-        reg = re.compile(rf"^({types})(\([\w\-\.]+\))?(!)?: (.*)([\s\S]*)")
+        reg = re.compile(rf"^({types})(\([\w\-\.]+\))?(!)?: (.*)([\s\S]*)", re.IGNORECASE)
         self.context.warning("Extracting commit log changes.")
 
         for i, (short_hash, commit_hash, log) in enumerate(logs):
             m = reg.match(log)
             if m:
                 self.context.debug("  Parsing commit log: %s", log.strip())
-                commit_type = m[1]
+                commit_type = m[1].lower()
                 scope = (m[2] or "").replace("(", "(`").replace(")", "`)")
                 breaking = m[3] is not None
                 description = m[4].strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,7 +105,7 @@ feat.header = "Features and Improvements"
 feat.semver = "minor"
 feature.header = "Features and Improvements"
 feature.semver = "minor"
-fix.header = "Bug fixes"
+Fix.header = "Bug fixes"
 misc.header = "Miscellaneous"
 test.header = "Bug fixes"
 """,

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -35,7 +35,7 @@ def conventional_commits(multiversion_repo):
     f = multiversion_repo.workspace / "hello.txt"
     hashes = []
     for msg in [
-        """fix(config): Detail about 4
+        """Fix(config): Detail about 4
 
 Refs: #4
 """,


### PR DESCRIPTION
Perform a case insensitive match on commit logs and normalise commit_types to lowercase.

closes #22 
Refs: #22