### PR TITLE
feat: Add support for github `closes #X` footer in commit messages to extract issue_ref.

### DIFF
--- a/changelog_gen/extractor.py
+++ b/changelog_gen/extractor.py
@@ -107,6 +107,7 @@ class ChangeExtractor:
                 for line in details.split("\n"):
                     for target, pattern in [
                         ("issue_ref", r"Refs: #?([\w-]+)"),
+                        ("issue_ref", r"closes #([\w-]+)"),  # support github closes footer
                         ("authors", r"Authors: (.*)"),
                     ]:
                         m = re.match(pattern, line)

--- a/docs/commits.md
+++ b/docs/commits.md
@@ -37,6 +37,11 @@ Optional footers that are parsed by `changelog-gen` are:
 * `BREAKING CHANGE:[ details]`
 * `Refs: [#]<issue_ref>`
 * `Authors: (<author>, ...)`
+* `closes #<issue_ref>`
+
+Note: The `closes #<issue_ref>` footed is included as a convenience for anyone
+using github and using PR title/description for the commit message to remove
+the need to also add a `Refs:` footer.
 
 ## Breaking changes
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -54,7 +54,7 @@ Refs: #1
         "update readme",
         """feat: Detail about 2
 
-Refs: #2
+closes #2
 """,
     ]:
         f.write_text(msg)


### PR DESCRIPTION
closes #27