### PR TITLE
feat: Separate footer parsing, information extraction and link generation.

### DIFF
--- a/changelog_gen/config.py
+++ b/changelog_gen/config.py
@@ -27,6 +27,8 @@ SUPPORTED_TYPES = {
 
 FOOTER_PARSERS = [
     r"(Refs)(: )(#?[\w-]+)",
+    # TODO(edgy): Parse github behind a github config
+    # https://github.com/NRWLDev/changelog-gen/issues/50
     r"(closes)( )(#[\w-]+)",
     r"(fixes)( )(#[\w-]+)",
     r"(Authors)(: )(.*)",
@@ -37,7 +39,7 @@ FOOTER_PARSERS = [
 class PostProcessConfig:
     """Post Processor configuration options."""
 
-    link_parser: dict[str, str] | None = None
+    link_generator: dict[str, str] | None = None
     verb: str = "POST"
     # The body to send as a post-processing command,
     # can have the entries: ::issue_ref::, ::version::
@@ -90,7 +92,8 @@ class Config:
     date_format: str | None = None
     version_string: str = "v{new_version}"
     footer_parsers: list[str] = dataclasses.field(default_factory=lambda: FOOTER_PARSERS[::])
-    link_parsers: list[dict[str, str]] = dataclasses.field(default_factory=list)
+    extractors: list[dict[str, str]] = dataclasses.field(default_factory=list)
+    link_generators: list[dict[str, str]] = dataclasses.field(default_factory=list)
     change_template: str | None = None
 
     # Hooks

--- a/changelog_gen/config.py
+++ b/changelog_gen/config.py
@@ -92,7 +92,8 @@ class Config:
     date_format: str | None = None
     version_string: str = "v{new_version}"
     footer_parsers: list[str] = dataclasses.field(default_factory=lambda: FOOTER_PARSERS[::])
-    extractors: list[dict[str, str]] = dataclasses.field(default_factory=list)
+    # footers can be a list to simplify configuration for footers sharing related information
+    extractors: list[dict[str, str | list[str]]] = dataclasses.field(default_factory=list)
     link_generators: list[dict[str, str]] = dataclasses.field(default_factory=list)
     change_template: str | None = None
 

--- a/changelog_gen/extractor.py
+++ b/changelog_gen/extractor.py
@@ -128,13 +128,18 @@ class ChangeExtractor:
                 extractions = defaultdict(list)
 
                 for extractor in self.context.config.extractors:
-                    footer = footers.get(extractor["footer"].lower())
-                    if footer is None:
-                        continue
+                    footer_keys = extractor["footer"]
+                    if not isinstance(footer_keys, list):
+                        footer_keys = [footer_keys]
 
-                    for m in re.finditer(extractor["pattern"], footer.value):
-                        for k, v in m.groupdict().items():
-                            extractions[k].append(v)
+                    for fkey in footer_keys:
+                        footer = footers.get(fkey.lower())
+                        if footer is None:
+                            continue
+
+                        for m in re.finditer(extractor["pattern"], footer.value):
+                            for k, v in m.groupdict().items():
+                                extractions[k].append(v)
 
                 header = self.type_headers.get(commit_type, commit_type)
                 change = Change(

--- a/docs/commits.md
+++ b/docs/commits.md
@@ -36,8 +36,10 @@ Optional footers that are parsed by `changelog-gen` are:
 
 * `BREAKING CHANGE:[ details]`
 * `Refs: [#]<issue_ref>`
-* `PR: [#]<pull_ref>`
 * `Authors: (<author>, ...)`
+
+Parsing additional/custom footers is supported with
+[footer_parsers](https://nrwldev.github.io/changelog-gen/configuration/#footer_parsers).
 
 ### Github support
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,7 +122,7 @@ footer_parsers = [
 ]
 ```
 
-### `link_parsers`
+### `link_generators`
   _**[optional]**_<br />
   **default**: None
 
@@ -141,12 +141,12 @@ footer_parsers = [
   Example:
 
 ```toml
-[[tool.changelog_gen.link_parsers]]
+[[tool.changelog_gen.link_generators]]
 target = "Refs"
 pattern = "#(\\d+)$"
 link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
 
-[[tool.changelog_gen.link_parsers]]
+[[tool.changelog_gen.link_generators]]
 target = "__change__"
 link = "https =//github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"
 text = "{0.short_hash}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,14 +130,20 @@ footer_parsers = [
   change object. Extractors should used named groups in regex expressions, this
   groups are the key to retrieve the information later in link generation or
   post processing. Extractors find all matches in a footer, so will be a
-  list of all matched values. `Refs: #1, #2` will be parsed as
+  list of all matched values. `Refs: 1, 2` will be parsed as
   `{"issue_ref": ["1", "2"]}` for example.
+
+  The footer configuration can be a single footer, or a list of related footers.
 
   Example:
 
 ```toml
 [[tool.changelog_gen.extractors]]
 footer = "Refs"
+pattern = '(?P<issue_ref>\d+)'
+
+[[tool.changelog_gen.extractors]]
+footer = ["closes", "fixes"]
 pattern = '#(?P<issue_ref>\d+)'
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,11 +168,11 @@ pattern = '#(?P<issue_ref>\d+)'
 ```toml
 [[tool.changelog_gen.link_generators]]
 source = "issue_ref"
-link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
+link = "https://github.com/NRWLDev/changelog-gen/issues/{0}"
 
 [[tool.changelog_gen.link_generators]]
 source = "__change__"
-link = "https =//github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"
+link = "https://github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"
 text = "{0.short_hash}"
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,32 +122,50 @@ footer_parsers = [
 ]
 ```
 
+### `extractors`
+  _**[optional]**_<br />
+  **default**: None
+
+  Define parsers to extract information from footers and store them on the
+  change object. Extractors should used named groups in regex expressions, this
+  groups are the key to retrieve the information later in link generation or
+  post processing. Extractors find all matches in a footer, so will be a
+  list of all matched values. `Refs: #1, #2` will be parsed as
+  `{"issue_ref": ["1", "2"]}` for example.
+
+  Example:
+
+```toml
+[[tool.changelog_gen.extractors]]
+footer = "Refs"
+pattern = '#(?P<issue_ref>\d+)'
+```
+
 ### `link_generators`
   _**[optional]**_<br />
   **default**: None
 
-  Define parsers to extract information from footers (or changelog entry) and
-  generate a link. Define a target footer, provide a regex pattern to extract
+  Make use of extracted information to generate links to different content.
+  Define an extraction source, provide a regex pattern to extract
   information from the footer, and define the link format, optionally define
   the link text format. Link text will default to the extracted information.
 
-  A special target `__change__` is provided to generate links using information
+  A special source `__change__` is provided to generate links using information
   directly from the change object (namely commit hashes).
 
-  Where a pattern is matched multiple times, a link for each match will be
-  created. This allows adding links to multiple authors from the Author for for
-  example.
+  Where an extraction contains multiple values, a link for each match will be
+  created. This allows adding links to multiple authors from the Author footer
+  for example.
 
   Example:
 
 ```toml
 [[tool.changelog_gen.link_generators]]
-target = "Refs"
-pattern = "#(\\d+)$"
+source = "issue_ref"
 link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
 
 [[tool.changelog_gen.link_generators]]
-target = "__change__"
+source = "__change__"
 link = "https =//github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"
 text = "{0.short_hash}"
 ```
@@ -404,7 +422,7 @@ pre_l = ["dev", "rc"]
 
   See example on below Jira configuration information.
 
-#### `post_process.url`
+#### `post_process.link_generator`
   _**[required]**_<br />
   **default**: None<br />
   The url to contact.
@@ -415,11 +433,14 @@ pre_l = ["dev", "rc"]
   **default**: POST<br />
   HTTP method to use.
 
-#### `post_process.body`
+#### `post_process.body_template`
   _**[optional]**_<br />
-  **default**: `{"body": "Released on ::version::"}`<br />
+  **default**: `{"body": "Released on {{ version }}"}`<br />
   The text to send to the API.
-  Can have the placeholders `::issue_ref::` and `::version::`.
+  Can have the placeholders
+  * `source` (usually the issue ref from the extracted information)
+  * `version` the version being released
+  * Any extracted key from defined extractors that had a match.
 
 #### `post_process.headers`
   _**[optional]**_<br />
@@ -444,9 +465,10 @@ pre_l = ["dev", "rc"]
 
 ```toml
 [tool.changelog_gen.post_process]
-url = "https://your-domain.atlassian.net/rest/api/2/issue/ISSUE-::issue_ref::/comment"
+link_generator.source = "issue_ref"
+link_generator.link = "https://your-domain.atlassian.net/rest/api/2/issue/ISSUE-{0}/comment"
 verb = "POST"
-body = '{"body": "Released on ::version::"}'
+body = '{"body": "Released on {{ version }}"}'
 auth_env = "JIRA_AUTH"
 headers."content-type" = "application/json"
 ```

--- a/docs/post_process.md
+++ b/docs/post_process.md
@@ -7,16 +7,16 @@ released as a part of.
 
 The configured [post
 process](https://nrwldev.github.io/changelog-gen/configuration/#post_process)
-url should contain an `::issue_ref::` place holder, when processing each commit
-issue, the url will be dynamically updated before
-being called.
+link generator can refer to any extracted information, if an extractor matches
+multiple times, the post process will be called for each match for that change.
 
-By default the url will be called using a `POST` request, but the http verb can
-be changed depending on the service being called, and its requirements. The
-request
-[body](https://nrwldev.github.io/changelog-gen/configuration/#post_processbody) can
-also be configured with a `::version::` placeholder to add a comment to an
-existing issue.
+By default the generated link will be called using a `POST` request, but the
+http verb can be changed depending on the service being called, and its
+requirements. The request
+[body](https://nrwldev.github.io/changelog-gen/configuration/#post_processbody_template)
+can also be configured with a jinja template, provided at render time will be
+the `version` string, the `source` from the extracted match, and all extracted
+key values.
 
 Optional
 [headers](https://nrwldev.github.io/changelog-gen/configuration/#post_processheaders)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,26 +71,18 @@ allowed_branches = [
 ]
 date_format = "- %Y-%m-%d"
 
-[[tool.changelog_gen.link_generators]]
-target = "closes"
-pattern = '#(\d+)$'
-link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
+[[tool.changelog_gen.extractors]]
+footer = ["closes", "fixes", "Refs"]
+pattern = '#(?P<issue_ref>\d+)'
 
 [[tool.changelog_gen.link_generators]]
-target = "fixes"
-pattern = '#(\d+)$'
-link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
-
-# Fall back in case a PR does not close an issue
-[[tool.changelog_gen.link_generators]]
-target = "Refs"
-pattern = '#(\d+)$'
-link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
+source = "issue_ref"
+link = "https://github.com/NRWLDev/changelog-gen/issues/{0}"
 
 [[tool.changelog_gen.link_generators]]
-target = "__change__"
+source = "__change__"
 text = "{0.short_hash}"
-link = "https =//github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"
+link = "https://github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"
 
 [[tool.changelog_gen.files]]
 filename = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,23 +71,23 @@ allowed_branches = [
 ]
 date_format = "- %Y-%m-%d"
 
-[[tool.changelog_gen.link_parsers]]
+[[tool.changelog_gen.link_generators]]
 target = "closes"
 pattern = '#(\d+)$'
 link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
 
-[[tool.changelog_gen.link_parsers]]
+[[tool.changelog_gen.link_generators]]
 target = "fixes"
 pattern = '#(\d+)$'
 link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
 
 # Fall back in case a PR does not close an issue
-[[tool.changelog_gen.link_parsers]]
+[[tool.changelog_gen.link_generators]]
 target = "Refs"
 pattern = '#(\d+)$'
 link = "https =//github.com/NRWLDev/changelog-gen/issues/{0}"
 
-[[tool.changelog_gen.link_parsers]]
+[[tool.changelog_gen.link_generators]]
 target = "__change__"
 text = "{0.short_hash}"
 link = "https =//github.com/NRWLDev/changelog-gen/commit/{0.commit_hash}"

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -39,7 +39,8 @@ footer_parsers = [
     '(fixes)( )(#[\w-]+)',
     '(Authors)(: )(.*)',
 ]
-link_parsers = []
+extractors = []
+link_generators = []
 hooks = []
 
 [type_headers]
@@ -64,7 +65,7 @@ test = 'Miscellaneous'
 
 
 def test_post_process_config_displayed(cli_runner, config_factory):
-    config_factory(post_process={"link_parser": {"target": "Refs", "link": "http://localhost"}})
+    config_factory(post_process={"link_generator": {"target": "Refs", "link": "http://localhost"}})
     result = cli_runner.invoke(["config"])
 
     assert result.exit_code == 0
@@ -74,7 +75,7 @@ verb = 'POST'
 body_template = '{"body": "Released on {{ version }}"}'
 auth_type = 'basic'
 
-[post_process.link_parser]
+[post_process.link_generator]
 target = 'Refs'
 link = 'http://localhost'
 

--- a/tests/cli/test_generate.py
+++ b/tests/cli/test_generate.py
@@ -145,10 +145,14 @@ def post_process_pyproject(cwd):
 [tool.changelog_gen]
 current_version = "0.0.0"
 commit = true
-post_process.link_parser."target" = "Refs"
-post_process.link_parser."pattern" = '#(\d+)$'
-post_process.link_parser."link" = "https://my-api/{0}/release"
+post_process.link_generator."source" = "issue_ref"
+post_process.link_generator."link" = "https://my-api/{0}/release"
 post_process.auth_env = "MY_API_AUTH"
+
+[[tool.changelog_gen.extractors]]
+footer = "Refs"
+pattern = '#(?P<issue_ref>\d+)'
+
 """,
     )
 
@@ -632,6 +636,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#4")],
+                extractions={"issue_ref": ["4"]},
                 links=[],
                 rendered="- Detail about 4",
             ),
@@ -644,6 +649,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#3")],
+                extractions={"issue_ref": ["3"]},
                 links=[],
                 rendered="- Detail about 3",
             ),
@@ -656,6 +662,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#2")],
+                extractions={"issue_ref": ["2"]},
                 links=[],
                 rendered="- Detail about 2",
             ),
@@ -668,6 +675,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#1")],
+                extractions={"issue_ref": ["1"]},
                 links=[],
                 rendered="- Detail about 1",
             ),
@@ -677,7 +685,7 @@ class TestDelegatesToPerIssuePostProcess:
             mock.call(
                 FakeContext(),
                 PostProcessConfig(
-                    link_parser={"target": "Refs", "pattern": r"#(\d+)$", "link": "https://my-api/{0}/release"},
+                    link_generator={"source": "issue_ref", "link": "https://my-api/{0}/release"},
                     auth_env="MY_API_AUTH",
                 ),
                 changes,
@@ -727,6 +735,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#4")],
+                extractions={"issue_ref": ["4"]},
                 links=[],
                 rendered="- Detail about 4",
             ),
@@ -739,6 +748,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#3")],
+                extractions={"issue_ref": ["3"]},
                 links=[],
                 rendered="- Detail about 3",
             ),
@@ -751,6 +761,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#2")],
+                extractions={"issue_ref": ["2"]},
                 links=[],
                 rendered="- Detail about 2",
             ),
@@ -763,6 +774,7 @@ class TestDelegatesToPerIssuePostProcess:
                 scope="",
                 breaking=False,
                 footers=[Footer(footer="Refs", separator=": ", value="#1")],
+                extractions={"issue_ref": ["1"]},
                 links=[],
                 rendered="- Detail about 1",
             ),
@@ -772,7 +784,7 @@ class TestDelegatesToPerIssuePostProcess:
             mock.call(
                 FakeContext(),
                 PostProcessConfig(
-                    link_parser={"target": "Refs", "pattern": r"#(\d+)$", "link": "https://my-api/{0}/release"},
+                    link_generator={"source": "issue_ref", "link": "https://my-api/{0}/release"},
                     auth_env="MY_API_AUTH",
                 ),
                 changes,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,11 +199,11 @@ release = true
 [tool.changelog_gen]
 current_version = "0.0.0"
 [tool.changelog_gen.post_process]
-link_parser."target" = "Refs"
-link_parser."pattern" = '#(\d+)$'
-link_parser."link" = "https://fake_rest_api/{0}"
+link_generator."target" = "Refs"
+link_generator."pattern" = '#(\d+)$'
+link_generator."link" = "https://fake_rest_api/{0}"
 verb = "PUT"
-body_template = '{"issue": "{{ link.text }}", "comment": "Released in {{ version }}"}'
+body_template = '{"issue": "{{ issue_ref }}", "comment": "Released in {{ version }}"}'
 auth_env = "MY_API_AUTH"
 headers."content-type" = "application/json"
 """,
@@ -211,9 +211,9 @@ headers."content-type" = "application/json"
 
         c = config.read()
         assert c.post_process == config.PostProcessConfig(
-            link_parser={"target": "Refs", "pattern": r"#(\d+)$", "link": "https://fake_rest_api/{0}"},
+            link_generator={"target": "Refs", "pattern": r"#(\d+)$", "link": "https://fake_rest_api/{0}"},
             verb="PUT",
-            body_template='{"issue": "{{ link.text }}", "comment": "Released in {{ version }}"}',
+            body_template='{"issue": "{{ issue_ref }}", "comment": "Released in {{ version }}"}',
             auth_env="MY_API_AUTH",
             headers={"content-type": "application/json"},
         )
@@ -342,7 +342,7 @@ def test_post_process_defaults():
     assert pp.body_template == '{"body": "Released on {{ version }}"}'
     assert pp.auth_type == "basic"
     for attr in [
-        "link_parser",
+        "link_generator",
         "headers",
         "auth_env",
     ]:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -228,8 +228,7 @@ def test_git_commit_extraction_include_all(conventional_commits):
 def test_git_commit_extraction_extractors(conventional_commits):
     hashes = conventional_commits
     extractors = [
-        {"footer": "Refs", "pattern": r"#(?P<issue_ref>\d+)"},
-        {"footer": "fixes", "pattern": r"#(?P<issue_ref>\d+)"},
+        {"footer": ["Refs", "fixes"], "pattern": r"#(?P<issue_ref>\d+)"},
         {"footer": "Authors", "pattern": r"@(?P<author>\w+)"},
     ]
     ctx = Context(Config(current_version="0.0.2", extractors=extractors))


### PR DESCRIPTION
extracting information from footers separately to link generation allows all extracted information to be made available in post_process body templates, and removes the need to hack the "link.text" into post_process bodies to get access to the triggering issue_ref.

closes #47