### PR TITLE
feat: Support special github scenarios via configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -418,6 +418,52 @@ pre_l = ["dev", "rc"]
   Enforce strict rules based on SemVer 2.0.0 and error if non conforming parser or
   serialisers are configured.
 
+
+## Github
+
+### `strip_pr_from_description`
+  _**[optional]**_<br />
+  **default**: False
+
+  Strip the `(#\d+)` from the end of github PR commit descriptions.
+
+  Example:
+
+```toml
+[tool.changelog_gen.github]
+strip_pr_from_description = true
+```
+
+### `extract_pr_from_description`
+  _**[optional]**_<br />
+  **default**: False
+
+  Extract the `(#\d+)` from the end of github PR commit descriptions, and track
+  it as a footer for later extraction and link generation. Creates a `PR` footer entry.
+
+  Example:
+
+```toml
+[tool.changelog_gen.github]
+extract_pr_from_description = true
+```
+
+### `extract_common_footers`
+  _**[optional]**_<br />
+  **default**: False
+
+  Extract supported keyword footers from github commits, `closes #1` etc.
+
+  Supported footers can be found
+  [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+  Example:
+
+```toml
+[tool.changelog_gen.github]
+extract_common_footers = true
+```
+
 ## Post processing
 
 ### `post_process`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ allowed_branches = [
 ]
 date_format = "- %Y-%m-%d"
 
+[tool.changelog_gen.github]
+strip_pr_from_description = true
+extract_pr_from_description = true
+extract_common_footers = true
+
 [[tool.changelog_gen.extractors]]
 footer = ["closes", "fixes", "Refs"]
 pattern = '#(?P<issue_ref>\d+)'

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -35,8 +35,6 @@ commit_types = [
 serialisers = ['{major}.{minor}.{patch}']
 footer_parsers = [
     '(Refs)(: )(#?[\w-]+)',
-    '(closes)( )(#[\w-]+)',
-    '(fixes)( )(#[\w-]+)',
     '(Authors)(: )(.*)',
 ]
 extractors = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,6 +179,25 @@ commit_types = [
             "test": "Miscellaneous",
         }
 
+    def test_read_picks_up_github_config(self, config_factory):
+        config_factory(
+            """
+[tool.changelog_gen]
+current_version = "0.0.0"
+[tool.changelog_gen.github]
+strip_pr_from_description = true
+extract_pr_from_description = true
+extract_common_footers = true
+""",
+        )
+
+        c = config.read()
+        assert c.github == config.GithubConfig(
+            strip_pr_from_description=True,
+            extract_pr_from_description=True,
+            extract_common_footers=True,
+        )
+
 
 class TestPostProcessConfig:
     def test_read_picks_up_no_post_process_config(self, config_factory):


### PR DESCRIPTION
Define behaviour for stripping PR information from github descriptions. Extract PR information as a footer, and extract common github keywords as footers.

closes #50